### PR TITLE
style: Use tabular-nums instead of monospaced font for numbers

### DIFF
--- a/src/jvmMain/resources/static/style.css
+++ b/src/jvmMain/resources/static/style.css
@@ -145,6 +145,7 @@ table tr:nth-child(odd) {
 
 table td {
     padding: .4em;
+    font-variant-numeric: tabular-nums;
 }
 
 /* form */
@@ -180,7 +181,7 @@ input:focus, .input:focus {
 }
 
 input[inputmode="numeric"], input[inputmode="decimal"] {
-    font-family: 'Consolas', 'Courier New', Courier, monospace;
+    font-variant-numeric: tabular-nums;
     text-align: end;
 }
 


### PR DESCRIPTION
Can't believe I wasn't aware of this css property